### PR TITLE
fix: make TablesClient.predict permissive to input data types

### DIFF
--- a/google/cloud/automl_v1beta1/tables/tables_client.py
+++ b/google/cloud/automl_v1beta1/tables/tables_client.py
@@ -59,7 +59,7 @@ def to_proto_value(value):
         # This check needs to happen before isinstance(value, int),
         # isinstance(value, int) returns True when value is bool.
         return struct_pb2.Value(bool_value=value), None
-    if isinstance(value, six.integer_types) or isinstance(value, float):
+    elif isinstance(value, six.integer_types) or isinstance(value, float):
         return struct_pb2.Value(number_value=value), None
     elif isinstance(value, six.string_types) or isinstance(value, six.text_type):
         return struct_pb2.Value(string_value=value), None

--- a/google/cloud/automl_v1beta1/tables/tables_client.py
+++ b/google/cloud/automl_v1beta1/tables/tables_client.py
@@ -23,7 +23,7 @@ import six
 from google.api_core.gapic_v1 import client_info
 from google.api_core import exceptions
 from google.cloud.automl_v1beta1 import gapic
-from google.cloud.automl_v1beta1.proto import data_types_pb2, data_items_pb2
+from google.cloud.automl_v1beta1.proto import data_items_pb2
 from google.cloud.automl_v1beta1.tables import gcs_client
 from google.protobuf import struct_pb2
 

--- a/google/cloud/automl_v1beta1/tables/tables_client.py
+++ b/google/cloud/automl_v1beta1/tables/tables_client.py
@@ -39,7 +39,7 @@ def to_proto_value(value):
   value: The Python value to be translated.
 
   Returns:
-  The translated google.protobuf.Value.
+  Tuple of the translated google.protobuf.Value and error if any.
   """
     # possible Python types (this is a Python3 module):
     # https://simplejson.readthedocs.io/en/latest/#encoders-and-decoders


### PR DESCRIPTION
The current implementation checks input instance's data type according
to column spec's data type. E.g., if the column spec is float, it
requires the input to be float or int, but not string. However, this
is not the same as tables API contract:

    float column data type could be string or number values.

The current code raises exception with error messages like

    TypeError: '0' has type str, but expected one of: int, long, float
    when passed in a string value for numeric columns, which should be
    allowed.

This PR changes the logic so that Python SDK side will be permissive
for the input data type - basically all JSON compatible data types are
allow. And rely on backend for the validation.
