### PR TITLE
docs: re-publish tables client documentation

### DIFF
--- a/docs/automl_v1beta1/services.rst
+++ b/docs/automl_v1beta1/services.rst
@@ -5,3 +5,4 @@ Services for Google Cloud Automl v1beta1 API
 
     auto_ml
     prediction_service
+    tables

--- a/docs/automl_v1beta1/tables.rst
+++ b/docs/automl_v1beta1/tables.rst
@@ -1,0 +1,11 @@
+Tables
+------------------------
+
+.. automodule:: google.cloud.automl_v1beta1.services.tables.gcs_client
+    :members:
+    :inherited-members:
+
+
+.. automodule:: google.cloud.automl_v1beta1.services.tables.tables_client
+    :members:
+    :inherited-members:

--- a/noxfile.py
+++ b/noxfile.py
@@ -188,8 +188,8 @@ def cover(session):
 def docs(session):
     """Build the docs for this library."""
 
-    session.install("-e", ".[pandas,storage]")
-    session.install("sphinx<3.0.0", "alabaster", "recommonmark")
+    session.install("-e", ".")
+    session.install("sphinx", "alabaster", "recommonmark")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
@@ -209,10 +209,8 @@ def docs(session):
 def docfx(session):
     """Build the docfx yaml files for this library."""
 
-    session.install("-e", ".[pandas,storage]")
-    session.install(
-        "sphinx<3.0.0", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml"
-    )
+    session.install("-e", ".")
+    session.install("sphinx", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(

--- a/synth.py
+++ b/synth.py
@@ -58,12 +58,11 @@ s.replace(
 
 s.replace(
     "docs/automl_v1beta1/services.rst",
-    """(google\.cloud\.automl_v1beta1\.services\.prediction_service
-    :members:
-    :inherited-members:)""",
-    """\g<1>\n.. automodule:: google.cloud.automl_v1beta1.services.tables
-    :members:
-    :inherited-members:"""
+    """auto_ml
+    prediction_service""",
+    """auto_ml
+    prediction_service
+    tables"""
 )
 
 # ----------------------------------------------------------------------------
@@ -79,9 +78,6 @@ python.py_samples(skip_readmes=True)
 
 s.move(templated_files)
 
-# TODO(busunkim): Use latest sphinx after microgenerator transition
-s.replace("noxfile.py", """['"]sphinx['"]""", '"sphinx<3.0.0"')
-# TODO(busunkim): Remove after microgenerator transition.
 # This is being added to AutoML because the proto comments are long and
 # regex replaces are a brittle temporary solution.
 s.replace(
@@ -89,13 +85,5 @@ s.replace(
 """'-W',  # warnings as errors
 \s+'-T',  \# show full traceback on exception""",
 """"-T",  # show full traceback on exception""")
-
-
-# install with extras (pandas, storage)
-s.replace(
-    "noxfile.py",
-    """session\.install\(['"]-e['"], ['"]\.['"]\)""",
-    """session.install("-e", ".[pandas,storage]")""",
-)
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)


### PR DESCRIPTION
The tables client documentation got deleted on accident - this re-adds the `TablesClient` and `GcsClient` under `automl_v1beta1`. Verify locally by running `nox -s docs` and looking at the output in `docs/_build/html`.

Fixes b/184554120