### PR TITLE
fix: switch to next() function rather than next() method

### DIFF
--- a/samples/beta/get_operation_status_test.py
+++ b/samples/beta/get_operation_status_test.py
@@ -30,7 +30,7 @@ def operation_id():
         project_location, filter_=""
     ).pages
     page = next(generator)
-    operation = page.next()
+    operation = next(page)
     yield operation.name
 
 

--- a/samples/snippets/get_operation_status_test.py
+++ b/samples/snippets/get_operation_status_test.py
@@ -31,7 +31,7 @@ def operation_id():
         project_location, filter_=""
     ).pages
     page = next(generator)
-    operation = page.next()
+    operation = next(page)
     yield operation.name
 
 


### PR DESCRIPTION
The `get_operation_status_test()` files for both v1 and v1beta1 use a mix of the `next()` function and `generator.next()` method. This PR switches to just use the `next()` function.

Fixes #231 and #232 
