### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,14 +1,14 @@
 {
-  "name": "automl",
-  "name_pretty": "Cloud AutoML",
-  "product_documentation": "https://cloud.google.com/automl/docs/",
-  "client_documentation": "https://googleapis.dev/python/automl/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559744",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-automl",
-  "distribution_name": "google-cloud-automl",
-  "api_id": "automl.googleapis.com",
-  "requires_billing": true
+    "name": "automl",
+    "name_pretty": "Cloud AutoML",
+    "product_documentation": "https://cloud.google.com/automl/docs/",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/automl/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559744",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-automl",
+    "distribution_name": "google-cloud-automl",
+    "api_id": "automl.googleapis.com",
+    "requires_billing": true
 }


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.