### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "automl",
     "name_pretty": "Cloud AutoML",
     "product_documentation": "https://cloud.google.com/automl/docs/",
-    "client_documentation": "https://googleapis.dev/python/automl/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/automl/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559744",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ transfer learning, and Neural Architecture Search technology.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-automl.svg
    :target: https://pypi.org/project/google-cloud-automl/
 .. _Cloud AutoML API: https://cloud.google.com/automl
-.. _Client Library Documentation: https://googleapis.dev/python/automl/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/automl/latest
 .. _Product Documentation:  https://cloud.google.com/automl
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.