### PR TITLE
fix: handle AttributeError in automl_v1beta1.TablesClient

### DIFF
--- a/google/cloud/automl_v1beta1/services/tables/tables_client.py
+++ b/google/cloud/automl_v1beta1/services/tables/tables_client.py
@@ -471,7 +471,7 @@ class TablesClient(object):
             try:
                 setattr(request, key, value)
                 method_kwargs.pop(key)
-            except KeyError:
+            except (AttributeError, KeyError):
                 continue
 
         return method_kwargs


### PR DESCRIPTION
The [test_list_datasets()](https://github.com/googleapis/python-automl/blob/main/tests/system/gapic/v1beta1/test_system_tables_client_v1.py#L62) and [test_list_models()](https://github.com/googleapis/python-automl/blob/main/tests/system/gapic/v1beta1/test_system_tables_client_v1.py#L73) systems tests include a `timeout` parameter which is not a valid field. The existing code handles the `KeyError` raised from `proto-plus` [here](https://github.com/googleapis/python-automl/blob/main/google/cloud/automl_v1beta1/services/tables/tables_client.py#L474). In https://github.com/googleapis/proto-plus-python/pull/301, the `KeyError` was changed to `AttributeError`. This PR adds handling the `AttributeError`. 

Alternatively, we could roll back the change in `proto-plus`.


Fixes #335 🦕
Fixes #336 🦕
