### PR TITLE
chore: allow releases from older versions

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,11 @@
 releaseType: python
 handleGHRelease: true
+  # NOTE: this section is generated in owlbot_main()
+  # See https://github.com/googleapis/synthtool/blob/master/synthtool/languages/python.py
+  branches:
+  - branch: v1
+    handleGHRelease: true
+    releaseType: python
+  - branch: v0
+    handleGHRelease: true
+    releaseType: python

--- a/owlbot.py
+++ b/owlbot.py
@@ -69,6 +69,7 @@ templated_files = common.py_library(
 )
 
 s.move(templated_files)
+python.configure_previous_major_version_branches()
 
 # Work around bug in templates https://github.com/googleapis/synthtool/pull/1335
 s.replace(".github/workflows/unittest.yml", "--fail-under=100", "--fail-under=99")


### PR DESCRIPTION
For testing purposes, do not merge.